### PR TITLE
Added "time lock" system

### DIFF
--- a/App/Control/PluginControl.Designer.cs
+++ b/App/Control/PluginControl.Designer.cs
@@ -57,6 +57,11 @@ namespace MognetPlugin.Control
             this.rchPluginLog = new System.Windows.Forms.RichTextBox();
             this.btnClearLog = new System.Windows.Forms.Button();
             this.grpAttributes = new System.Windows.Forms.GroupBox();
+            this.lblEndTime = new System.Windows.Forms.Label();
+            this.lblStartTime = new System.Windows.Forms.Label();
+            this.dtpEndTime = new System.Windows.Forms.DateTimePicker();
+            this.dtpStartTime = new System.Windows.Forms.DateTimePicker();
+            this.chkTimeEnabled = new System.Windows.Forms.CheckBox();
             this.lblSort = new System.Windows.Forms.Label();
             this.cmbSort = new System.Windows.Forms.ComboBox();
             this.chlAttributes = new System.Windows.Forms.CheckedListBox();
@@ -187,6 +192,11 @@ namespace MognetPlugin.Control
             // 
             // grpAttributes
             // 
+            this.grpAttributes.Controls.Add(this.lblEndTime);
+            this.grpAttributes.Controls.Add(this.lblStartTime);
+            this.grpAttributes.Controls.Add(this.dtpEndTime);
+            this.grpAttributes.Controls.Add(this.dtpStartTime);
+            this.grpAttributes.Controls.Add(this.chkTimeEnabled);
             this.grpAttributes.Controls.Add(this.lblSort);
             this.grpAttributes.Controls.Add(this.cmbSort);
             this.grpAttributes.Controls.Add(this.chlAttributes);
@@ -197,9 +207,60 @@ namespace MognetPlugin.Control
             this.grpAttributes.TabStop = false;
             this.grpAttributes.Text = "Include Attributes";
             // 
+            // lblEndTime
+            // 
+            this.lblEndTime.Location = new System.Drawing.Point(3, 307);
+            this.lblEndTime.Name = "lblEndTime";
+            this.lblEndTime.Size = new System.Drawing.Size(70, 23);
+            this.lblEndTime.TabIndex = 12;
+            this.lblEndTime.Text = "End Time:";
+            this.lblEndTime.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // lblStartTime
+            // 
+            this.lblStartTime.Location = new System.Drawing.Point(3, 285);
+            this.lblStartTime.Name = "lblStartTime";
+            this.lblStartTime.Size = new System.Drawing.Size(70, 23);
+            this.lblStartTime.TabIndex = 11;
+            this.lblStartTime.Text = "Start Time:";
+            this.lblStartTime.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // dtpEndTime
+            // 
+            this.dtpEndTime.Enabled = false;
+            this.dtpEndTime.Format = System.Windows.Forms.DateTimePickerFormat.Time;
+            this.dtpEndTime.Location = new System.Drawing.Point(79, 310);
+            this.dtpEndTime.Name = "dtpEndTime";
+            this.dtpEndTime.ShowUpDown = true;
+            this.dtpEndTime.Size = new System.Drawing.Size(91, 20);
+            this.dtpEndTime.TabIndex = 10;
+            this.dtpEndTime.ValueChanged += new System.EventHandler(this.dtpEndTime_ValueChanged);
+            // 
+            // dtpStartTime
+            // 
+            this.dtpStartTime.Enabled = false;
+            this.dtpStartTime.Format = System.Windows.Forms.DateTimePickerFormat.Time;
+            this.dtpStartTime.Location = new System.Drawing.Point(79, 284);
+            this.dtpStartTime.Name = "dtpStartTime";
+            this.dtpStartTime.ShowUpDown = true;
+            this.dtpStartTime.Size = new System.Drawing.Size(91, 20);
+            this.dtpStartTime.TabIndex = 9;
+            this.dtpStartTime.ValueChanged += new System.EventHandler(this.dtpStartTime_ValueChanged);
+            // 
+            // chkTimeEnabled
+            // 
+            this.chkTimeEnabled.AutoSize = true;
+            this.chkTimeEnabled.Location = new System.Drawing.Point(6, 261);
+            this.chkTimeEnabled.Name = "chkTimeEnabled";
+            this.chkTimeEnabled.Size = new System.Drawing.Size(139, 17);
+            this.chkTimeEnabled.TabIndex = 8;
+            this.chkTimeEnabled.Text = "Only post logs between:";
+            this.chkTimeEnabled.UseVisualStyleBackColor = true;
+            this.chkTimeEnabled.CheckedChanged += new System.EventHandler(this.chkTimeEnabled_CheckedChanged);
+            // 
             // lblSort
             // 
-            this.lblSort.Location = new System.Drawing.Point(6, 340);
+            this.lblSort.Location = new System.Drawing.Point(3, 232);
             this.lblSort.Name = "lblSort";
             this.lblSort.Size = new System.Drawing.Size(45, 23);
             this.lblSort.TabIndex = 6;
@@ -210,17 +271,32 @@ namespace MognetPlugin.Control
             // 
             this.cmbSort.Items.AddRange(new object[] {
             ""});
-            this.cmbSort.Location = new System.Drawing.Point(57, 342);
+            this.cmbSort.Location = new System.Drawing.Point(54, 234);
             this.cmbSort.Name = "cmbSort";
-            this.cmbSort.Size = new System.Drawing.Size(113, 21);
+            this.cmbSort.Size = new System.Drawing.Size(116, 21);
             this.cmbSort.TabIndex = 7;
             // 
             // chlAttributes
             // 
             this.chlAttributes.CheckOnClick = true;
+            this.chlAttributes.Items.AddRange(new object[] {
+            "1",
+            "2",
+            "3",
+            "4",
+            "5",
+            "6",
+            "7",
+            "8",
+            "9",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14"});
             this.chlAttributes.Location = new System.Drawing.Point(6, 16);
             this.chlAttributes.Name = "chlAttributes";
-            this.chlAttributes.Size = new System.Drawing.Size(164, 319);
+            this.chlAttributes.Size = new System.Drawing.Size(164, 214);
             this.chlAttributes.TabIndex = 1;
             // 
             // PluginControl
@@ -236,6 +312,7 @@ namespace MognetPlugin.Control
             this.grpOptions.PerformLayout();
             this.grpHttpLog.ResumeLayout(false);
             this.grpAttributes.ResumeLayout(false);
+            this.grpAttributes.PerformLayout();
             this.ResumeLayout(false);
 
         }
@@ -296,5 +373,10 @@ namespace MognetPlugin.Control
         private Label lblChannelName;
         private Label lbDiscordChannel;
         private Label lblDiscordGuild;
+        private Label lblEndTime;
+        private Label lblStartTime;
+        private DateTimePicker dtpEndTime;
+        private DateTimePicker dtpStartTime;
+        private CheckBox chkTimeEnabled;
     }
 }

--- a/App/Control/PluginControl.cs
+++ b/App/Control/PluginControl.cs
@@ -49,6 +49,11 @@ namespace MognetPlugin.Control
             this.chlAttributes.SetItemChecked(13, PluginSettings.GetSetting<bool>("CritHealPerc"));
 
             this.cmbSort.Text = PluginSettings.GetSetting<string>("SortBy");
+
+            this.chkTimeEnabled.Checked = PluginSettings.GetSetting<bool>("TimeEnabled");
+            this.dtpStartTime.Value = DateTime.Parse(PluginSettings.GetSetting<string>("StartTime"));
+            this.dtpEndTime.Value = DateTime.Parse(PluginSettings.GetSetting<string>("EndTime"));
+
         }
 
         private void chlAttributes_ItemCheck(object sender, EventArgs e)
@@ -177,6 +182,33 @@ namespace MognetPlugin.Control
             }
 
             return false;
+        }
+
+        private void chkTimeEnabled_CheckedChanged(object sender, EventArgs e)
+        {
+            PluginSettings.SetSetting("TimeEnabled", chkEnabled.Checked);
+
+            if (this.chkTimeEnabled.Checked)
+            {
+                LogInfo("Time lock enabled. Parses will only be sent to discord between the specified times.");
+            }
+            else
+            {
+                LogInfo("Time lock disabled. Parses will be sent as usual.");
+            }
+
+            this.dtpStartTime.Enabled = chkTimeEnabled.Checked;
+            this.dtpEndTime.Enabled = chkTimeEnabled.Checked;
+        }
+
+        private void dtpStartTime_ValueChanged(object sender, EventArgs e)
+        {
+            PluginSettings.SetSetting("StartTime", dtpStartTime.Value.ToString());
+        }
+
+        private void dtpEndTime_ValueChanged(object sender, EventArgs e)
+        {
+            PluginSettings.SetSetting("EndTime", dtpEndTime.Value.ToString());
         }
     }
 }

--- a/App/MognetPlugin.csproj
+++ b/App/MognetPlugin.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Advanced Combat Tracker">
-      <HintPath>Thirdparty\ACT\Advanced Combat Tracker.exe</HintPath>
+      <HintPath>C:\Program Files (x86)\Advanced Combat Tracker\Advanced Combat Tracker.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/App/PluginMain.cs
+++ b/App/PluginMain.cs
@@ -58,11 +58,19 @@ namespace MognetPlugin
         {
             if (PluginUtil.IsPluginEnabled())
             {
-                try
-                {
+                //try
+                //{
                     Log Log = PluginUtil.ACTEncounterToModel(encounterInfo.encounter);
                     if (Log != null)
                     {
+
+                        if (PluginSettings.GetSetting<bool>("TimeEnabled") == true && PluginUtil.TimeBetween(DateTime.Now, DateTime.Parse(PluginSettings.GetSetting<string>("StartTime")).TimeOfDay, DateTime.Parse(PluginSettings.GetSetting<string>("EndTime")).TimeOfDay) == false)
+                        {
+                            PluginControl.LogInfo("Parse *not* sent to your Discord channel due to time lock rules.");
+                            PluginControl.LogInfo("Waiting for the next encounter...");
+                            return;
+                        }
+
                         string Json = PluginUtil.ToJson(Log);
                         bool Sent = Service.PostDiscord(Json, PluginSettings.GetSetting<string>("Token"));
 
@@ -80,11 +88,11 @@ namespace MognetPlugin
                     {
                         PluginControl.LogInfo("Nothing to be sent. Waiting for the next encounter...");
                     }
-                }
-                catch (Exception e)
-                {
-                    PluginControl.LogInfo("Something went wrong. Debug info:" + Environment.NewLine + e.ToString());
-                }
+                //}
+                //catch (Exception e)
+                //{
+                //    PluginControl.LogInfo("Something went wrong. Debug info:" + Environment.NewLine + e.ToString());
+                //}
             }
         }
     }

--- a/App/Properties/PluginSettings.Designer.cs
+++ b/App/Properties/PluginSettings.Designer.cs
@@ -8,6 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
+using System;
+
 namespace MognetPlugin.Properties {
     
     
@@ -259,6 +261,51 @@ namespace MognetPlugin.Properties {
             }
             set {
                 this["SortBy"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("8:00 PM")]
+        public string StartTime
+        {
+            get
+            {
+                return ((string)(this["StartTime"]));
+            }
+            set
+            {
+                this["StartTime"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("10:00 PM")]
+        public string EndTime
+        {
+            get
+            {
+                return ((string)(this["EndTime"]));
+            }
+            set
+            {
+                this["EndTime"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool TimeEnabled
+        {
+            get
+            {
+                return ((bool)(this["TimeEnabled"]));
+            }
+            set
+            {
+                this["TimeEnabled"] = value;
             }
         }
     }

--- a/App/Util/PluginUtil.cs
+++ b/App/Util/PluginUtil.cs
@@ -140,5 +140,16 @@ namespace MognetPlugin.Util
             Match m = r.Match(text);
             return m.Groups[0].ToString().Trim();
         }
+
+        public static bool TimeBetween(DateTime datetime, TimeSpan start, TimeSpan end)
+        {
+            // convert datetime to a TimeSpan
+            TimeSpan now = datetime.TimeOfDay;
+            // see if start comes before end
+            if (start < end)
+                return start <= now && now <= end;
+            // start is after end, so do the inverse comparison
+            return !(end < now && now < start);
+        }
     }
 }


### PR DESCRIPTION
I've added a system that allows you to set a certain time for logs to be posted (and to otherwise ignore them) - It checks the time when an encounter finishes and will send it if it's between the specified time (and the feature is enabled). Otherwise, it simply waits for the next one.

I did this because I kept leaving it on before/after raid and spamming our channel... I was going to add a "select duties to output" but I figure that would be way more complicated for no additional features compared to this.

I've tested it a bit and it seems to work fine but please double check my work etc.